### PR TITLE
Refactor SmsService to use OAuth2 Client Credentials Grant

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,9 @@ authenticate using their phone number. The process includes:
 This modular plugin uses a multi-step flow and is designed with separation of concerns in mind, using a dedicated
 service layer for SMS and phone number processing.
 
-## New Feature: OAuth2 Authentication for SMS Service
+## New Feature: Dual Authentication Support for SMS Service
 
-The `SmsService` has been refactored to replace **Basic Authentication** with **OAuth2 Client Credentials Grant** for secure communication with the SMS provider.  
-
-The plugin now fetches an **access token** from a `/token` endpoint, using it for `/sms/send` and `/sms/validate` API calls.
-
----
+The `SmsService` has been enhanced to support both **Basic Authentication** and **OAuth2 Client Credentials Grant** for secure communication with the SMS provider. The plugin prioritizes OAuth2 if the required environment variables are set; otherwise, it falls back to Basic Auth.
 
 ## 2. How to Use It
 
@@ -62,9 +58,11 @@ docker run -d \
   -e KEYCLOAK_ADMIN_PASSWORD=password \
   -e SMS_API_URL=http://your-sms-api-url \
   -e SMS_API_COUNTRY_PATTERN='cm|de|fr' \
+  -e SMS_API_AUTH_USERNAME=someuser \
+  -e SMS_API_AUTH_PASSWORD=somepassword \
   -e OAUTH2_CLIENT_ID=some-client-id \
-  -e OAUTH2_CLIENT_SECRET=some-cient-secret \
-  -e OAUTH2_TOKEN_ENDPOINT=http://your-sms-api-url/token \
+  -e OAUTH2_CLIENT_SECRET=some-client-secret \
+  -e OAUTH2_TOKEN_ENDPOINT=http://auth-server.example.com/oauth/token \
   -v /path/to/keycloak-phonenumber-login.jar:/opt/keycloak/providers/keycloak-phonenumber-login.jar \
   quay.io/keycloak/keycloak:26.1.2 start-dev
 ```
@@ -117,12 +115,16 @@ spec:
               value: "http://your-sms-api-url"
             - name: SMS_API_COUNTRY_PATTERN
               value: "cm|de|fr"
+            - name: SMS_API_AUTH_USERNAME
+              value: "someuser"
+            - name: SMS_API_AUTH_PASSWORD
+              value: "somepassword"
             - name: OAUTH2_CLIENT_ID
               value: "some-client-id"
             - name: OAUTH2_CLIENT_SECRET
               value: "some-client-secret"
             - name: OAUTH2_TOKEN_ENDPOINT
-              value: "http://your-sms-api-url/token"
+              value: "http://auth-server.example.com/oauth/token"
           volumeMounts:
             - name: plugin-volume
               mountPath: /opt/keycloak/providers
@@ -142,12 +144,13 @@ The following environment variables are used by the plugin:
 - **KC_LOG_CONSOLE_COLOR**: Enables colored logging in the console (set to `'true'` or `'false'`).  
 - **KC_HTTP_PORT**: The HTTP port on which Keycloak runs.  
 - **SMS_API_URL**: The base URL of the SMS API service.  
-- **SMS_API_COUNTRY_PATTERN**: A regex pattern to match supported phone number country codes.  
+- **SMS_API_COUNTRY_PATTERN**: A regex pattern to match supported phone number country codes.
+- **SMS_API_AUTH_USERNAME**: The basic auth username for the SMS API.
+- **SMS_API_AUTH_PASSWORD**: The basic auth password for the SMS API.
 - **OAUTH2_CLIENT_ID**: The client ID for OAuth2 authentication with the SMS provider.  
 - **OAUTH2_CLIENT_SECRET**: The client secret for OAuth2 authentication with the SMS provider.  
 - **OAUTH2_TOKEN_ENDPOINT**: The URL of the token endpoint for OAuth2 authentication (e.g., `http://your-sms-api-url/token`).  
 
-**Note**: The older `SMS_API_AUTH_USERNAME` and `SMS_API_AUTH_PASSWORD` variables are **deprecated** and replaced with the above OAuth2 variables for enhanced security.  
 
 Configure these variables in your deployment (Docker, Kubernetes, etc.) as shown in the examples above.  
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ authenticate using their phone number. The process includes:
 This modular plugin uses a multi-step flow and is designed with separation of concerns in mind, using a dedicated
 service layer for SMS and phone number processing.
 
+## New Feature: OAuth2 Authentication for SMS Service
+
+The `SmsService` has been refactored to replace **Basic Authentication** with **OAuth2 Client Credentials Grant** for secure communication with the SMS provider.  
+
+The plugin now fetches an **access token** from a `/token` endpoint, using it for `/sms/send` and `/sms/validate` API calls.
+
 ---
 
 ## 2. How to Use It
@@ -56,8 +62,9 @@ docker run -d \
   -e KEYCLOAK_ADMIN_PASSWORD=password \
   -e SMS_API_URL=http://your-sms-api-url \
   -e SMS_API_COUNTRY_PATTERN='cm|de|fr' \
-  -e SMS_API_AUTH_USERNAME=someuser \
-  -e SMS_API_AUTH_PASSWORD=somepassword \
+  -e OAUTH2_CLIENT_ID=some-client-id \
+  -e OAUTH2_CLIENT_SECRET=some-cient-secret \
+  -e OAUTH2_TOKEN_ENDPOINT=http://your-sms-api-url/token \
   -v /path/to/keycloak-phonenumber-login.jar:/opt/keycloak/providers/keycloak-phonenumber-login.jar \
   quay.io/keycloak/keycloak:26.1.2 start-dev
 ```
@@ -110,10 +117,12 @@ spec:
               value: "http://your-sms-api-url"
             - name: SMS_API_COUNTRY_PATTERN
               value: "cm|de|fr"
-            - name: SMS_API_AUTH_USERNAME
-              value: "someuser"
-            - name: SMS_API_AUTH_PASSWORD
-              value: "somepassword"
+            - name: OAUTH2_CLIENT_ID
+              value: "some-client-id"
+            - name: OAUTH2_CLIENT_SECRET
+              value: "some-client-secret"
+            - name: OAUTH2_TOKEN_ENDPOINT
+              value: "http://your-sms-api-url/token"
           volumeMounts:
             - name: plugin-volume
               mountPath: /opt/keycloak/providers
@@ -128,24 +137,19 @@ it into the appropriate directory.
 
 The following environment variables are used by the plugin:
 
-- **KEYCLOAK_ADMIN:**  
-  The administrator username for Keycloak.
-- **KEYCLOAK_ADMIN_PASSWORD:**  
-  The administrator password for Keycloak.
-- **KC_LOG_CONSOLE_COLOR:**  
-  Enables colored logging in the console (set to 'true' or 'false').
-- **KC_HTTP_PORT:**  
-  The HTTP port on which Keycloak runs.
-- **SMS_API_URL:**  
-  The base URL of the SMS API service.
-- **SMS_API_COUNTRY_PATTERN:**  
-  A regex pattern to match supported phone number country codes.
-- **SMS_API_AUTH_USERNAME:**  
-  The basic auth username for the SMS API.
-- **SMS_API_AUTH_PASSWORD:**  
-  The basic auth password for the SMS API.
+- **KEYCLOAK_ADMIN**: The administrator username for Keycloak.  
+- **KEYCLOAK_ADMIN_PASSWORD**: The administrator password for Keycloak.  
+- **KC_LOG_CONSOLE_COLOR**: Enables colored logging in the console (set to `'true'` or `'false'`).  
+- **KC_HTTP_PORT**: The HTTP port on which Keycloak runs.  
+- **SMS_API_URL**: The base URL of the SMS API service.  
+- **SMS_API_COUNTRY_PATTERN**: A regex pattern to match supported phone number country codes.  
+- **OAUTH2_CLIENT_ID**: The client ID for OAuth2 authentication with the SMS provider.  
+- **OAUTH2_CLIENT_SECRET**: The client secret for OAuth2 authentication with the SMS provider.  
+- **OAUTH2_TOKEN_ENDPOINT**: The URL of the token endpoint for OAuth2 authentication (e.g., `http://your-sms-api-url/token`).  
 
-Configure these variables in your deployment (Docker, Kubernetes, etc.) as shown in the examples above.
+**Note**: The older `SMS_API_AUTH_USERNAME` and `SMS_API_AUTH_PASSWORD` variables are **deprecated** and replaced with the above OAuth2 variables for enhanced security.  
+
+Configure these variables in your deployment (Docker, Kubernetes, etc.) as shown in the examples above.  
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ docker run -d \
   -e SMS_API_AUTH_PASSWORD=somepassword \
   -e OAUTH2_CLIENT_ID=some-client-id \
   -e OAUTH2_CLIENT_SECRET=some-client-secret \
-  -e OAUTH2_TOKEN_ENDPOINT=http://auth-server.example.com/oauth/token \
+  -e OAUTH2_TOKEN_ENDPOINT=http://token-mock:8080/token \
   -v /path/to/keycloak-phonenumber-login.jar:/opt/keycloak/providers/keycloak-phonenumber-login.jar \
   quay.io/keycloak/keycloak:26.1.2 start-dev
 ```
@@ -124,7 +124,7 @@ spec:
             - name: OAUTH2_CLIENT_SECRET
               value: "some-client-secret"
             - name: OAUTH2_TOKEN_ENDPOINT
-              value: "http://auth-server.example.com/oauth/token"
+              value: "http://token-mock:8080/token"
           volumeMounts:
             - name: plugin-volume
               mountPath: /opt/keycloak/providers
@@ -149,7 +149,7 @@ The following environment variables are used by the plugin:
 - **SMS_API_AUTH_PASSWORD**: The basic auth password for the SMS API.
 - **OAUTH2_CLIENT_ID**: The client ID for OAuth2 authentication with the SMS provider.  
 - **OAUTH2_CLIENT_SECRET**: The client secret for OAuth2 authentication with the SMS provider.  
-- **OAUTH2_TOKEN_ENDPOINT**: The URL of the token endpoint for OAuth2 authentication (e.g., `http://your-sms-api-url/token`).  
+- **OAUTH2_TOKEN_ENDPOINT**: The URL of the token endpoint for OAuth2 authentication (e.g., `http://token-mock:8080/token` for testing, or `http://your-auth-server/oauth/token` in production).
 
 
 Configure these variables in your deployment (Docker, Kubernetes, etc.) as shown in the examples above.  

--- a/compose.yml
+++ b/compose.yml
@@ -1,14 +1,14 @@
 x-keycloak-common-env: &keycloak-common-env
   KEYCLOAK_ADMIN: admin
   KEYCLOAK_ADMIN_PASSWORD: password
-  KC_LOG_CONSOLE_COLOR: 'true'
+  KC_LOG_CONSOLE_COLOR: "true"
   SMS_API_URL: http://prism:4010
-  SMS_API_COUNTRY_PATTERN: 'cm|de|fr'
+  SMS_API_COUNTRY_PATTERN: "cm|de|fr"
   SMS_API_AUTH_USERNAME: someuser
   SMS_API_AUTH_PASSWORD: somepassword
   OAUTH2_CLIENT_ID: some-client-id
   OAUTH2_CLIENT_SECRET: some-client-secret
-  OAUTH2_TOKEN_ENDPOINT: http://auth-server.example.com/oauth/token  # External token endpoint
+  OAUTH2_TOKEN_ENDPOINT: http://token-mock:4011/token # External token endpoint
 
 x-keycloak-common-extra: &keycloak-common-extra
   entrypoint: /bin/sh
@@ -28,7 +28,7 @@ services:
   keycloak-22:
     image: quay.io/keycloak/keycloak:22.0.5
     ports:
-      - '9022:9022'
+      - "9022:9022"
     environment:
       <<: *keycloak-common-env
       KC_HTTP_PORT: 9022
@@ -36,7 +36,7 @@ services:
   keycloak-23:
     image: quay.io/keycloak/keycloak:23.0.7
     ports:
-      - '9023:9023'
+      - "9023:9023"
     environment:
       <<: *keycloak-common-env
       KC_HTTP_PORT: 9023
@@ -44,7 +44,7 @@ services:
   keycloak-24:
     image: quay.io/keycloak/keycloak:24.0.5
     ports:
-      - '9024:9024'
+      - "9024:9024"
     environment:
       <<: *keycloak-common-env
       KC_HTTP_PORT: 9024
@@ -53,7 +53,7 @@ services:
   keycloak-25:
     image: quay.io/keycloak/keycloak:25.0.6
     ports:
-      - '9025:9025'
+      - "9025:9025"
     environment:
       <<: *keycloak-common-env
       KC_HTTP_PORT: 9025
@@ -62,7 +62,7 @@ services:
   keycloak-26:
     image: quay.io/keycloak/keycloak:26.1.3
     ports:
-      - '9026:9026'
+      - "9026:9026"
     environment:
       <<: *keycloak-common-env
       KC_HTTP_PORT: 9026
@@ -80,3 +80,16 @@ services:
       - /openapi/sms-open-api.yml
     volumes:
       - ./openapi:/openapi
+
+  # Mock server for OAuth2 token endpoint
+  token-mock:
+    image: node:18-slim
+    ports:
+      - "4011:4011"
+    command: >
+      /bin/sh -c "
+      npm install -g json-server &&
+      json-server --host 0.0.0.0 --port 4011 /tmp/token.json
+      "
+    volumes:
+      - ./token.json:/tmp/token.json:ro

--- a/compose.yml
+++ b/compose.yml
@@ -4,8 +4,9 @@ x-keycloak-common-env: &keycloak-common-env
   KC_LOG_CONSOLE_COLOR: 'true'
   SMS_API_URL: http://prism:4010
   SMS_API_COUNTRY_PATTERN: 'cm|de|fr'
-  SMS_API_AUTH_USERNAME: someuser
-  SMS_API_AUTH_PASSWORD: somepassword
+  OAUTH2_CLIENT_ID: some-client-id
+  OAUTH2_CLIENT_SECRET: some-client-secret
+  OAUTH2_TOKEN_ENDPOINT: http://prism:4010/token  # Mock token endpoint
 
 x-keycloak-common-extra: &keycloak-common-extra
   entrypoint: /bin/sh

--- a/compose.yml
+++ b/compose.yml
@@ -4,9 +4,11 @@ x-keycloak-common-env: &keycloak-common-env
   KC_LOG_CONSOLE_COLOR: 'true'
   SMS_API_URL: http://prism:4010
   SMS_API_COUNTRY_PATTERN: 'cm|de|fr'
+  SMS_API_AUTH_USERNAME: someuser
+  SMS_API_AUTH_PASSWORD: somepassword
   OAUTH2_CLIENT_ID: some-client-id
   OAUTH2_CLIENT_SECRET: some-client-secret
-  OAUTH2_TOKEN_ENDPOINT: http://prism:4010/token  # Mock token endpoint
+  OAUTH2_TOKEN_ENDPOINT: http://auth-server.example.com/oauth/token  # External token endpoint
 
 x-keycloak-common-extra: &keycloak-common-extra
   entrypoint: /bin/sh

--- a/compose.yml
+++ b/compose.yml
@@ -8,7 +8,7 @@ x-keycloak-common-env: &keycloak-common-env
   SMS_API_AUTH_PASSWORD: somepassword
   OAUTH2_CLIENT_ID: some-client-id
   OAUTH2_CLIENT_SECRET: some-client-secret
-  OAUTH2_TOKEN_ENDPOINT: http://token-mock:4011/token # External token endpoint
+  OAUTH2_TOKEN_ENDPOINT: http://token-mock:8080/token # External token endpoint
 
 x-keycloak-common-extra: &keycloak-common-extra
   entrypoint: /bin/sh
@@ -23,12 +23,16 @@ x-keycloak-common-extra: &keycloak-common-extra
     - ./target/:/tmp/libs-target:ro
   links:
     - prism
+    - token-mock
 
 services:
   keycloak-22:
     image: quay.io/keycloak/keycloak:22.0.5
     ports:
       - "9022:9022"
+    depends_on:
+      token-mock:
+        condition: service_healthy
     environment:
       <<: *keycloak-common-env
       KC_HTTP_PORT: 9022
@@ -37,6 +41,9 @@ services:
     image: quay.io/keycloak/keycloak:23.0.7
     ports:
       - "9023:9023"
+    depends_on:
+      token-mock:
+        condition: service_healthy
     environment:
       <<: *keycloak-common-env
       KC_HTTP_PORT: 9023
@@ -45,6 +52,9 @@ services:
     image: quay.io/keycloak/keycloak:24.0.5
     ports:
       - "9024:9024"
+    depends_on:
+      token-mock:
+        condition: service_healthy
     environment:
       <<: *keycloak-common-env
       KC_HTTP_PORT: 9024
@@ -54,6 +64,9 @@ services:
     image: quay.io/keycloak/keycloak:25.0.6
     ports:
       - "9025:9025"
+    depends_on:
+      token-mock:
+        condition: service_healthy
     environment:
       <<: *keycloak-common-env
       KC_HTTP_PORT: 9025
@@ -63,6 +76,9 @@ services:
     image: quay.io/keycloak/keycloak:26.1.3
     ports:
       - "9026:9026"
+    depends_on:
+      token-mock:
+        condition: service_healthy
     environment:
       <<: *keycloak-common-env
       KC_HTTP_PORT: 9026
@@ -83,13 +99,14 @@ services:
 
   # Mock server for OAuth2 token endpoint
   token-mock:
-    image: node:18-slim
+    image: wiremock/wiremock:3.6.0
     ports:
-      - "4011:4011"
-    command: >
-      /bin/sh -c "
-      npm install -g json-server &&
-      json-server --host 0.0.0.0 --port 4011 /tmp/token.json
-      "
+      - "4011:8080"
     volumes:
-      - ./token.json:/tmp/token.json:ro
+      - ./wiremock:/home/wiremock
+    command: --global-response-templating --verbose
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 10

--- a/openapi/sms-open-api.yml
+++ b/openapi/sms-open-api.yml
@@ -30,6 +30,7 @@ paths:
       description: Send an SMS to the phone number provided
       operationId: sendSms
       security:
+        - basic_auth: []
         - oauth2: []
       requestBody:
         description: Send sms request
@@ -53,6 +54,7 @@ paths:
       description: Send an SMS to the phone number provided
       operationId: validateSms
       security:
+        - basic_auth: []
         - oauth2: []
       requestBody:
         description: Validate sms request
@@ -69,60 +71,6 @@ paths:
               schema:
                 $ref: "#/components/schemas/ConfirmTanResponse"
 
-  /token:  # New endpoint for OAuth2 token issuance
-    post:
-      tags:
-        - sms
-      summary: Get OAuth2 access token
-      description: Issues an access token using the Client Credentials Grant
-      operationId: getToken
-      requestBody:
-        description: Token request
-        content:
-          application/x-www-form-urlencoded:
-            schema:
-              type: object
-              properties:
-                grant_type:
-                  type: string
-                  example: "client_credentials"
-                client_id:
-                  type: string
-                  example: "some-client-id"
-                client_secret:
-                  type: string
-                  example: "some-client-secret"
-              required:
-                - grant_type
-                - client_id
-                - client_secret
-      responses:
-        200:
-          description: "Token issued successfully"
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  access_token:
-                    type: string
-                    example: "mock-access-token"
-                  token_type:
-                    type: string
-                    example: "Bearer"
-                  expires_in:
-                    type: integer
-                    example: 3600
-        401:
-          description: "Invalid client credentials"
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    example: "invalid_client"
 components:
   schemas:
     ConfirmTanRequest:
@@ -171,9 +119,12 @@ components:
       required:
         - status
   securitySchemes:
+    basic_auth:
+      type: http
+      scheme: basic
     oauth2:
       type: oauth2
       flows:
         clientCredentials:
-          tokenUrl: /token
+          tokenUrl: 'https://external-auth-server.example.com/oauth/token'  # Placeholder
           scopes: {}

--- a/openapi/sms-open-api.yml
+++ b/openapi/sms-open-api.yml
@@ -30,7 +30,7 @@ paths:
       description: Send an SMS to the phone number provided
       operationId: sendSms
       security:
-        - basic_auth: [ ]
+        - oauth2: []
       requestBody:
         description: Send sms request
         content:
@@ -53,7 +53,7 @@ paths:
       description: Send an SMS to the phone number provided
       operationId: validateSms
       security:
-        - basic_auth: [ ]
+        - oauth2: []
       requestBody:
         description: Validate sms request
         content:
@@ -69,6 +69,60 @@ paths:
               schema:
                 $ref: "#/components/schemas/ConfirmTanResponse"
 
+  /token:  # New endpoint for OAuth2 token issuance
+    post:
+      tags:
+        - sms
+      summary: Get OAuth2 access token
+      description: Issues an access token using the Client Credentials Grant
+      operationId: getToken
+      requestBody:
+        description: Token request
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                grant_type:
+                  type: string
+                  example: "client_credentials"
+                client_id:
+                  type: string
+                  example: "some-client-id"
+                client_secret:
+                  type: string
+                  example: "some-client-secret"
+              required:
+                - grant_type
+                - client_id
+                - client_secret
+      responses:
+        200:
+          description: "Token issued successfully"
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  access_token:
+                    type: string
+                    example: "mock-access-token"
+                  token_type:
+                    type: string
+                    example: "Bearer"
+                  expires_in:
+                    type: integer
+                    example: 3600
+        401:
+          description: "Invalid client credentials"
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    example: "invalid_client"
 components:
   schemas:
     ConfirmTanRequest:
@@ -117,6 +171,9 @@ components:
       required:
         - status
   securitySchemes:
-    basic_auth:
-      type: http
-      scheme: basic
+    oauth2:
+      type: oauth2
+      flows:
+        clientCredentials:
+          tokenUrl: /token
+          scopes: {}

--- a/openapi/sms-open-api.yml
+++ b/openapi/sms-open-api.yml
@@ -46,6 +46,17 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/SendSmsResponse"
+        401:
+          description: "Unauthorized - Invalid or missing authentication"
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    example: "unauthorized"
+                    
   /sms/validate:
     post:
       tags:
@@ -70,6 +81,16 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ConfirmTanResponse"
+        401:
+          description: "Unauthorized - Invalid or missing authentication"
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    example: "unauthorized"
 
 components:
   schemas:

--- a/openapi/sms-open-api.yml
+++ b/openapi/sms-open-api.yml
@@ -14,6 +14,8 @@ externalDocs:
   description: Find out more about calling setting up an external service to verify phone number
   url: https://ssegning.com
 servers:
+  - url: http://prism:4010
+    description: Mock server
   - url: http://localhost:8080
     description: Dev server
   - url: https://sms-api-server:port
@@ -147,5 +149,5 @@ components:
       type: oauth2
       flows:
         clientCredentials:
-          tokenUrl: 'https://external-auth-server.example.com/oauth/token'  # Placeholder
+          tokenUrl: 'http://token-mock:8080/token'
           scopes: {}

--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,20 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.14</version>
+        </dependency>
+        
+        <!-- Apache HttpClient 4.x (MIME support) -->
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpmime</artifactId>
+            <version>4.5.14</version>
+        </dependency>
+        <!-- Your other dependencies -->
+
+        <dependency>
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging</artifactId>
             <scope>provided</scope>

--- a/src/main/java/com/vymalo/keycloak/authenticator/PhoneNumberChooseUser.java
+++ b/src/main/java/com/vymalo/keycloak/authenticator/PhoneNumberChooseUser.java
@@ -35,8 +35,7 @@ public class PhoneNumberChooseUser extends AbstractPhoneNumberAuthenticator {
         var user = context.getUser();
 
         if (user != null && !user.isEnabled()) {
-            event.clone()
-                    .detail("phone_number", phoneNumber)
+            event.detail("phone_number", phoneNumber)
                     .user(user)
                     .error(Errors.USER_DISABLED);
             context.clearUser();

--- a/src/main/java/com/vymalo/keycloak/authenticator/PhoneNumberSendTan.java
+++ b/src/main/java/com/vymalo/keycloak/authenticator/PhoneNumberSendTan.java
@@ -26,9 +26,8 @@ public class PhoneNumberSendTan extends AbstractPhoneNumberAuthenticator {
 
         if (hash$.isPresent()) {
             final var hash = hash$.get();
-            event.clone()
-                    .detail("sms_hash", hash)
-                    .success();
+            event.detail("sms_hash", hash)
+                 .success();
 
             context
                     .getAuthenticationSession()

--- a/src/main/java/com/vymalo/keycloak/authenticator/PhoneNumberValidateTan.java
+++ b/src/main/java/com/vymalo/keycloak/authenticator/PhoneNumberValidateTan.java
@@ -64,8 +64,7 @@ public class PhoneNumberValidateTan extends AbstractPhoneNumberAuthenticator {
             context.success();
         } else {
             final var event = context.getEvent();
-            event.clone()
-                    .detail("sms_code", code)
+            event.detail("sms_code", code)
                     .user(user)
                     .error(Errors.INVALID_CODE);
 

--- a/src/main/java/com/vymalo/keycloak/services/SmsService.java
+++ b/src/main/java/com/vymalo/keycloak/services/SmsService.java
@@ -10,12 +10,23 @@ import com.vymalo.api.server.model.ConfirmTanRequest;
 import com.vymalo.api.server.model.SendSmsRequest;
 import com.vymalo.keycloak.constants.ConfigKey;
 import com.vymalo.keycloak.constants.Utils;
-import lombok.*;
+import lombok.Data;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.jbosslog.JBossLog;
-import org.apache.commons.lang3.StringUtils;
+import org.apache.http.NameValuePair;
+import org.apache.http.client.entity.UrlEncodedFormEntity;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.message.BasicNameValuePair;
+import org.apache.http.util.EntityUtils;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.utils.KeycloakModelUtils;
+import org.keycloak.util.JsonSerialization;
 
+import java.io.IOException;
 import java.util.*;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -23,26 +34,31 @@ import java.util.stream.Collectors;
 @JBossLog
 public class SmsService {
     public static final String DEFAULT_PHONE_KEY_NAME = "phoneNumber";
-    public static final PhoneNumberUtil phoneNumberUtil = com.google.i18n.phonenumbers.PhoneNumberUtil.getInstance();
+    public static final PhoneNumberUtil phoneNumberUtil = PhoneNumberUtil.getInstance();
     @Getter
     private static final Set<CountryPhoneCode> allCountries;
 
     @Getter
     private static final SmsService instance;
 
+    private static String accessToken;
+    private static long tokenExpirationTime; // Timestamp (millis) when token expires
+
     static {
         final var smsUrl = Utils.getEnv(ConfigKey.CONF_PRP_SMS_URL);
-        final var basicUsr = Utils.getEnv(ConfigKey.BASIC_AUTH_USERNAME);
-        final var basicPwd = Utils.getEnv(ConfigKey.BASIC_AUTH_PASSWORD);
+        final var clientId = Utils.getEnv("OAUTH2_CLIENT_ID");
+        final var clientSecret = Utils.getEnv("OAUTH2_CLIENT_SECRET");
+        final var tokenEndpoint = Utils.getEnv("OAUTH2_TOKEN_ENDPOINT");
         final var allowedCountries = Pattern.compile(Utils.getEnv(ConfigKey.ALLOWED_COUNTRY_PATTERN, "*"), Pattern.CASE_INSENSITIVE).asMatchPredicate();
 
         final var apiClient = new ApiClient();
         apiClient.updateBaseUri(smsUrl);
         apiClient.setRequestInterceptor(builder -> {
-            if (StringUtils.isNotEmpty(basicUsr) && StringUtils.isNotEmpty(basicPwd)) {
-                final var valueToEncode = basicUsr + ":" + basicPwd;
-                final var basicAuth = "Basic " + Base64.getEncoder().encodeToString(valueToEncode.getBytes());
-                builder.header("Authorization", basicAuth);
+            try {
+                String token = getAccessToken(clientId, clientSecret, tokenEndpoint);
+                builder.header("Authorization", "Bearer " + token);
+            } catch (Exception e) {
+                log.error("Failed to set OAuth2 token", e);
             }
         });
 
@@ -72,6 +88,33 @@ public class SmsService {
 
     private SmsService(ApiClient apiClient) {
         this.smsApi = new SmsApi(apiClient);
+    }
+
+    // Fetch or refresh OAuth2 access token
+    private static synchronized String getAccessToken(String clientId, String clientSecret, String tokenEndpoint) throws IOException {
+        if (accessToken == null || System.currentTimeMillis() >= tokenExpirationTime) {
+            try (CloseableHttpClient client = HttpClients.createDefault()) {
+                HttpPost post = new HttpPost(tokenEndpoint);
+                post.setHeader("Content-Type", "application/x-www-form-urlencoded");
+
+                List<NameValuePair> params = new ArrayList<>();
+                params.add(new BasicNameValuePair("grant_type", "client_credentials"));
+                params.add(new BasicNameValuePair("client_id", clientId));
+                params.add(new BasicNameValuePair("client_secret", clientSecret));
+                post.setEntity(new UrlEncodedFormEntity(params));
+
+                try (CloseableHttpResponse response = client.execute(post)) {
+                    String json = EntityUtils.toString(response.getEntity());
+                    Map<String, Object> tokenData = JsonSerialization.readValue(json, Map.class);
+                    accessToken = (String) tokenData.get("access_token");
+                    int expiresIn = (int) tokenData.get("expires_in");
+                    tokenExpirationTime = System.currentTimeMillis() + (expiresIn * 1000L) - 30000;
+                }
+            } catch (Exception e) {
+                throw new IOException("Failed to fetch OAuth2 token", e);
+            }
+        }
+        return accessToken;
     }
 
     public Optional<String> sendSmsAndGetHash(String phoneNumber) {
@@ -106,7 +149,6 @@ public class SmsService {
             final var firstPhoneNumber = phoneNumber.stream().findFirst().flatMap(this::parse);
             return firstPhoneNumber.isPresent();
         }
-
         return true;
     }
 

--- a/token.json
+++ b/token.json
@@ -1,8 +1,0 @@
-{
-    "token": {
-      "access_token": "mock-token-12345",
-      "expires_in": 3600,
-      "token_type": "Bearer"
-    }
-  }
-  

--- a/token.json
+++ b/token.json
@@ -1,0 +1,8 @@
+{
+    "token": {
+      "access_token": "mock-token-12345",
+      "expires_in": 3600,
+      "token_type": "Bearer"
+    }
+  }
+  

--- a/wiremock/mappings/health.json
+++ b/wiremock/mappings/health.json
@@ -1,0 +1,15 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "/health"
+  },
+  "response": {
+    "status": 200,
+    "jsonBody": {
+      "status": "healthy"
+    },
+    "headers": {
+      "Content-Type": "application/json"
+    }
+  }
+}

--- a/wiremock/mappings/token-mock.json
+++ b/wiremock/mappings/token-mock.json
@@ -1,0 +1,19 @@
+{
+  "request": {
+    "method": "POST",
+    "url": "/token",
+    "headers": {
+      "Content-Type": {
+        "contains": "application/x-www-form-urlencoded"
+      }
+    }
+  },
+  "response": {
+    "status": 200,
+    "jsonBody": {
+      "access_token": "mock-token-12345",
+      "expires_in": 3600,
+      "token_type": "Bearer"
+    }
+  }
+}


### PR DESCRIPTION
**Description:**
This PR refactors the `SmsService` class to replace Basic Authentication with OAuth2 Client Credentials Grant for interacting with the SMS provider API. Key changes include:
- Added token fetching logic with caching in `getAccessToken`.
- Updated the `ApiClient` interceptor to use `Authorization: Bearer` headers.
- Tested successfully with a Prism mock server and the `ssegning-tw-01` realm's 'Phone number login' flow.

**Main Changes:**
- `SmsService.java`: Implemented OAuth2 logic.
- `sms-open-api.yml`: Added `/token` endpoint and updated security to `oauth2`.
- `compose.yml`: Added `OAUTH2_CLIENT_ID`, `OAUTH2_CLIENT_SECRET`, `OAUTH2_TOKEN_ENDPOINT`.
- `README.md`: Updated with OAuth2 details, Docker-Kubernetes examples, and environment variables.