### PR TITLE
Test Basic auth fallback after OAuth2 failure

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,6 +133,18 @@
             <version>5.11.3</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.11.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.tomakehurst</groupId>
+            <artifactId>wiremock-jre8</artifactId>
+            <version>2.35.1</version>
+            <scope>test</scope>
+        </dependency>
 
 
         <!-- End: OpenApi -->
@@ -159,6 +171,12 @@
                         </path>
                     </annotationProcessorPaths>
                 </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.5</version>
             </plugin>
 
             <plugin>

--- a/src/main/java/com/vymalo/keycloak/services/SmsService.java
+++ b/src/main/java/com/vymalo/keycloak/services/SmsService.java
@@ -63,7 +63,12 @@ public class SmsService {
                     String token = getAccessToken(clientId, clientSecret, tokenEndpoint);
                     builder.header("Authorization", "Bearer " + token);
                 } catch (Exception e) {
-                    log.error("Failed to set OAuth2 token, falling back to no auth", e);
+                    log.error("Failed to set OAuth2 token, falling back to basic auth", e);
+                    if (StringUtils.isNotEmpty(basicUsr) && StringUtils.isNotEmpty(basicPwd)) {
+                        final var valueToEncode = basicUsr + ":" + basicPwd;
+                        final var basicAuth = "Basic " + Base64.getEncoder().encodeToString(valueToEncode.getBytes());
+                        builder.header("Authorization", basicAuth);
+                    }
                 }
             }
             // Fall back to Basic Auth if credentials are provided

--- a/src/test/java/com/vymalo/keycloak/services/SmsServiceTest.java
+++ b/src/test/java/com/vymalo/keycloak/services/SmsServiceTest.java
@@ -1,0 +1,56 @@
+package com.vymalo.keycloak.services;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Optional;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SmsServiceTest {
+
+    private WireMockServer server;
+
+    @BeforeEach
+    void setup() {
+        server = new WireMockServer(WireMockConfiguration.options().dynamicPort());
+        server.start();
+    }
+
+    @AfterEach
+    void teardown() {
+        server.stop();
+    }
+
+    @Test
+    void fallsBackToBasicAuthWhenTokenRequestFails() {
+        String user = "user";
+        String pass = "pass";
+        String basicAuth = "Basic " + Base64.getEncoder().encodeToString((user + ":" + pass).getBytes(StandardCharsets.UTF_8));
+
+        server.stubFor(post(urlEqualTo("/token")).willReturn(aResponse().withStatus(500)));
+
+        server.stubFor(post(urlEqualTo("/sms/send"))
+                .withHeader("Authorization", equalTo(basicAuth))
+                .willReturn(okJson("{\"status\":\"SENT\",\"hash\":\"xyz\"}")));
+
+        System.setProperty("SMS_API_URL", server.baseUrl());
+        System.setProperty("SMS_API_AUTH_USERNAME", user);
+        System.setProperty("SMS_API_AUTH_PASSWORD", pass);
+        System.setProperty("OAUTH2_CLIENT_ID", "client");
+        System.setProperty("OAUTH2_CLIENT_SECRET", "secret");
+        System.setProperty("OAUTH2_TOKEN_ENDPOINT", server.baseUrl() + "/token");
+
+        Optional<String> hash = SmsService.getInstance().sendSmsAndGetHash("+1234567890");
+        assertTrue(hash.isPresent());
+
+        server.verify(postRequestedFor(urlEqualTo("/sms/send"))
+                .withHeader("Authorization", equalTo(basicAuth)));
+    }
+}


### PR DESCRIPTION
## Summary
- add WireMock-based test verifying SmsService falls back to Basic auth when OAuth2 token fetch fails
- fallback to Basic auth in SmsService when token request fails
- add WireMock and JUnit engine test dependencies

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM, Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b1668a47c08329aadda40315742375