### PR TITLE
feature: Add LOGGER implmentation for local testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,9 @@ All declared providers are now implemented:
 - `RABBITMQ`
 - `KAFKA`
 - `SNS_SQS`
+- `LOGGER`
 
-`API` is the REST provider. `AMQP`, `RABBITMQ`, `KAFKA`, and `SNS_SQS` now each have their own `SmsGateway` implementation in their respective packages.
+`API` is the REST provider. `AMQP`, `RABBITMQ`, `KAFKA`, `SNS_SQS`, and `LOGGER` now each have their own `SmsGateway` implementation in their respective packages.
 For non-`API` providers, the plugin generates a TAN + hash, publishes a `SEND_SMS` event payload to the configured transport, and validates the submitted TAN locally (hash-bound, one-time, 5-minute TTL).
 
 `SMS_API_URL` is interpreted per provider:
@@ -52,6 +53,7 @@ For non-`API` providers, the plugin generates a TAN + hash, publishes a `SEND_SM
 - `RABBITMQ`: RabbitMQ AMQP URI (example: `amqp://guest:guest@localhost:5672/%2f`)
 - `AMQP`: AMQP URI
 - `SNS_SQS`: optional AWS endpoint override (useful for LocalStack)
+- `LOGGER`: Not needed, provide a dummy value to pass validation
 
 ## 2. How to Use It
 
@@ -68,6 +70,7 @@ curl -L -o keycloak-phonenumber-amqp.jar https://github.com/vymalo/keycloak-phon
 curl -L -o keycloak-phonenumber-rabbitmq.jar https://github.com/vymalo/keycloak-phone-number/releases/download/v<version>/keycloak-phonenumber-rabbitmq-<version>.jar
 curl -L -o keycloak-phonenumber-kafka.jar https://github.com/vymalo/keycloak-phone-number/releases/download/v<version>/keycloak-phonenumber-kafka-<version>.jar
 curl -L -o keycloak-phonenumber-sns-sqs.jar https://github.com/vymalo/keycloak-phone-number/releases/download/v<version>/keycloak-phonenumber-sns-sqs-<version>.jar
+curl -L -o keycloak-phonenumber-logger.jar https://github.com/vymalo/keycloak-phone-number/releases/download/v<version>/keycloak-phonenumber-logger-<version>.jar
 ```
 
 ### Mounting into Keycloak
@@ -96,7 +99,7 @@ docker run -d \
   quay.io/keycloak/keycloak:26.5.2 start-dev
 ```
 
-Mount the gateway jar that matches your configured `smsProvider` (`API`, `AMQP`, `RABBITMQ`, `KAFKA`, `SNS_SQS`).
+Mount the gateway jar that matches your configured `smsProvider` (`API`, `AMQP`, `RABBITMQ`, `KAFKA`, `SNS_SQS`, `LOGGER`).
 
 #### Kubernetes Example
 
@@ -206,6 +209,7 @@ The plugin is built as a monorepo under `packages/`:
 - **`packages/keycloak-phonenumber-rabbitmq`**: RabbitMQ provider implementation.
 - **`packages/keycloak-phonenumber-amqp`**: AMQP provider implementation.
 - **`packages/keycloak-phonenumber-kafka`**: Kafka provider implementation.
+- **`packages/keycloak-phonenumber-logger`**: Logger implementation for local testing
 - **`packages/keycloak-phonenumber-theme`**: login theme package.
 
 Dependency injection (via CDI) is used to wire components together, making the system more modular, testable, and

--- a/packages/keycloak-phonenumber-logger/pom.xml
+++ b/packages/keycloak-phonenumber-logger/pom.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.vymalo.keycloak</groupId>
+        <artifactId>keycloak-phone-number</artifactId>
+        <version>26.5.2</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>keycloak-phonenumber-logger</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.vymalo.keycloak</groupId>
+            <artifactId>keycloak-phonenumber-abstractions</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/packages/keycloak-phonenumber-logger/src/main/java/com/vymalo/keycloak/logger/LoggerSmsGateway.java
+++ b/packages/keycloak-phonenumber-logger/src/main/java/com/vymalo/keycloak/logger/LoggerSmsGateway.java
@@ -1,0 +1,25 @@
+package com.vymalo.keycloak.logger;
+
+import com.vymalo.keycloak.services.AbstractCodeGeneratingSmsGateway;
+import com.vymalo.keycloak.services.SmsRequestContext;
+import com.vymalo.keycloak.services.SmsServiceConfig;
+
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public final class LoggerSmsGateway extends AbstractCodeGeneratingSmsGateway {
+    private static final Logger LOGGER = Logger.getLogger(LoggerSmsGateway.class.getName());
+    private static final String PROVIDER = "LOGGER";
+
+    public LoggerSmsGateway(SmsServiceConfig config) {
+        super(PROVIDER);
+    }
+
+    @Override
+    protected boolean dispatch(String payload, SmsRequestContext requestContext, String phoneNumber, String code, String hash) {
+        LOGGER.info("OTP for " + phoneNumber + " is " + code);
+        return true;
+    }
+}

--- a/packages/keycloak-phonenumber-logger/src/main/java/com/vymalo/keycloak/logger/LoggerSmsGatewayFactory.java
+++ b/packages/keycloak-phonenumber-logger/src/main/java/com/vymalo/keycloak/logger/LoggerSmsGatewayFactory.java
@@ -1,0 +1,17 @@
+package com.vymalo.keycloak.logger;
+
+import com.vymalo.keycloak.services.SmsGateway;
+import com.vymalo.keycloak.services.SmsGatewayFactory;
+import com.vymalo.keycloak.services.SmsServiceConfig;
+
+public final class LoggerSmsGatewayFactory implements SmsGatewayFactory {
+    @Override
+    public String type() {
+        return "LOGGER";
+    }
+
+    @Override
+    public SmsGateway create(SmsServiceConfig config) {
+        return new LoggerSmsGateway(config);
+    }
+}

--- a/packages/keycloak-phonenumber-logger/src/main/resources/META-INF/services/com.vymalo.keycloak.services.SmsGatewayFactory
+++ b/packages/keycloak-phonenumber-logger/src/main/resources/META-INF/services/com.vymalo.keycloak.services.SmsGatewayFactory
@@ -1,0 +1,1 @@
+com.vymalo.keycloak.logger.LoggerSmsGatewayFactory

--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,7 @@
         <module>packages/keycloak-phonenumber-rabbitmq</module>
         <module>packages/keycloak-phonenumber-amqp</module>
         <module>packages/keycloak-phonenumber-kafka</module>
+        <module>packages/keycloak-phonenumber-logger</module>
         <module>packages/keycloak-phonenumber-login</module>
         <module>packages/keycloak-phonenumber-theme</module>
     </modules>


### PR DESCRIPTION
Local testing and doing POCs is a challenge. You would need to signup for an SMS delivery platform, and possibly pay a fee. In India you would also need to produce legal documents before activating the SMS platform.

This PR adds a `LOGGER` implementation that simply logs the OTP to console.